### PR TITLE
Normalize in-app request type handling

### DIFF
--- a/Example/OpenIapExample/Screens/PurchaseFlowScreen.swift
+++ b/Example/OpenIapExample/Screens/PurchaseFlowScreen.swift
@@ -224,7 +224,7 @@ struct PurchaseFlowScreen: View {
     private func loadProducts() {
         Task {
             do {
-                try await iapStore.fetchProducts(skus: productIds, type: .inapp)
+                try await iapStore.fetchProducts(skus: productIds, type: .inApp)
                 await MainActor.run {
                     if iapStore.products.isEmpty {
                         errorMessage = "No products found. Please check your App Store Connect configuration."

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ class StoreViewModel: ObservableObject {
             // Fetch products
             try await iapStore.fetchProducts(
                 skus: ["product1", "product2"],
-                type: .inapp
+                type: .inApp
             )
         }
     }
@@ -312,7 +312,7 @@ struct OpenIapProduct {
     let id: String
     let title: String
     let description: String
-    let type: String  // "inapp" or "subs"
+    let type: String  // "in-app" (preferred) or legacy "inapp" (deprecated, removal in 1.2.0) or "subs"
     let displayPrice: String
     let currency: String
     let price: Double?

--- a/Sources/Models/OpenIapProductRequest.swift
+++ b/Sources/Models/OpenIapProductRequest.swift
@@ -1,11 +1,23 @@
 import Foundation
 
 /// Request product type for filtering when fetching products
-/// Maps to literal strings: "inapp", "subs", "all"
+/// Maps to literal strings: "in-app" (preferred), legacy "inapp" (deprecated, removal scheduled for 1.2.0), "subs", "all"
 public enum OpenIapRequestProductType: String, Codable, Sendable {
+    internal static let legacyInAppRawValue = "inapp"
+    internal static let modernInAppRawValue = "in-app"
+
+    @available(*, deprecated, message: "'inapp' is deprecated and will be removed in 1.2.0. Use .inApp instead.")
     case inapp = "inapp"
+    case inApp = "in-app"
     case subs = "subs"
     case all = "all"
+
+    internal var normalizedRawValue: String {
+        if rawValue == Self.legacyInAppRawValue {
+            return Self.modernInAppRawValue
+        }
+        return rawValue
+    }
 }
 
 /// Product request parameters following OpenIAP specification
@@ -13,27 +25,82 @@ public struct OpenIapProductRequest: Codable, Equatable, Sendable {
     /// Product SKUs to fetch
     public let skus: [String]
     
-    /// Product type filter: "inapp" (default), "subs", or "all"
+    /// Product type filter: "in-app" (default), "subs", or "all". The legacy value "inapp" is still accepted but will be removed in 1.2.0.
     public let type: String
-    
-    public init(skus: [String], type: String = "inapp") {
+
+    private enum CodingKeys: String, CodingKey {
+        case skus
+        case type
+    }
+
+    /// Create request specifying raw type string. Passing `nil` or an empty string defaults to "in-app".
+    public init(skus: [String], type: String? = nil) {
         self.skus = skus
-        self.type = type
+        self.type = OpenIapProductRequest.normalizeType(type)
     }
     
     /// Convenience initializer with RequestProductType enum
-    public init(skus: [String], type: OpenIapRequestProductType = .inapp) {
+    public init(skus: [String], type: OpenIapRequestProductType = .inApp) {
         self.skus = skus
-        self.type = type.rawValue
+        self.type = type.normalizedRawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let skus = try container.decode([String].self, forKey: .skus)
+        let rawType = try container.decodeIfPresent(String.self, forKey: .type)
+        self.init(skus: skus, type: rawType ?? OpenIapProductRequest.defaultTypeValue)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(skus, forKey: .skus)
+        try container.encode(type, forKey: .type)
     }
     
     /// Get the type as RequestProductType enum
     public var requestType: OpenIapRequestProductType {
-        return OpenIapRequestProductType(rawValue: type) ?? .inapp
+        if let parsedType = OpenIapRequestProductType(rawValue: type) {
+            if parsedType.rawValue == OpenIapRequestProductType.legacyInAppRawValue {
+                return .inApp
+            }
+            return parsedType
+        }
+
+        let normalized = OpenIapProductRequest.normalizeType(type)
+        return OpenIapRequestProductType(rawValue: normalized) ?? .inApp
+    }
+
+    private static let defaultTypeValue = OpenIapRequestProductType.modernInAppRawValue
+
+    private static func normalizeType(_ rawType: String?) -> String {
+        guard let rawType else {
+            return defaultTypeValue
+        }
+
+        let trimmed = rawType.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return defaultTypeValue
+        }
+
+        if let productType = OpenIapRequestProductType(rawValue: trimmed) {
+            return productType.normalizedRawValue
+        }
+
+        let lowered = trimmed.lowercased()
+        switch lowered {
+        case OpenIapRequestProductType.legacyInAppRawValue, OpenIapRequestProductType.modernInAppRawValue:
+            return OpenIapRequestProductType.modernInAppRawValue
+        case OpenIapRequestProductType.subs.rawValue:
+            return OpenIapRequestProductType.subs.rawValue
+        case OpenIapRequestProductType.all.rawValue:
+            return OpenIapRequestProductType.all.rawValue
+        default:
+            return defaultTypeValue
+        }
     }
 }
 
 // Backward compatibility aliases
 public typealias RequestProductType = OpenIapRequestProductType
 public typealias ProductRequest = OpenIapProductRequest
-

--- a/Sources/OpenIapModule.swift
+++ b/Sources/OpenIapModule.swift
@@ -171,8 +171,8 @@ public final class OpenIapModule: NSObject, OpenIapModuleProtocol {
             
             // Filter by type using enum
             switch params.requestType {
-            case .inapp:
-                OpenIapLog.debug("🔷 [OpenIapModule] Filtering for inapp products")
+            case .inapp, .inApp:
+                OpenIapLog.debug("🔷 [OpenIapModule] Filtering for in-app products")
                 openIapProducts = openIapProducts.filter { product in
                     let isInApp = product.productType == .inapp
                     OpenIapLog.debug("🔷 [OpenIapModule] Product \(product.id): productType=\(product.productType), isInApp=\(isInApp)")

--- a/Tests/OpenIapTests.swift
+++ b/Tests/OpenIapTests.swift
@@ -189,4 +189,18 @@ final class OpenIapTests: XCTestCase {
         XCTAssertEqual(receipt.inAppPurchases.count, 1)
         XCTAssertEqual(receipt.inAppPurchases.first?.id, "trans1")
     }
+
+    func testProductRequestTypeNormalization() {
+        let legacyRequest = OpenIapProductRequest(skus: ["sku1"], type: "inapp")
+        XCTAssertEqual(legacyRequest.type, "in-app")
+        XCTAssertEqual(legacyRequest.requestType, .inApp)
+
+        let modernRequest = OpenIapProductRequest(skus: ["sku1"], type: "in-app")
+        XCTAssertEqual(modernRequest.type, "in-app")
+        XCTAssertEqual(modernRequest.requestType, .inApp)
+
+        let enumRequest = OpenIapProductRequest(skus: ["sku1"], type: .inApp)
+        XCTAssertEqual(enumRequest.type, "in-app")
+        XCTAssertEqual(enumRequest.requestType, .inApp)
+    }
 }


### PR DESCRIPTION
## Summary
- Accept both `inapp` and `in-app` while defaulting to the preferred form
- Update module filtering, docs, sample, and add regression coverage

## Testing
- `swift test` *(fails: sandbox denied access to SwiftPM cache directories)*
